### PR TITLE
chore: add CODEOWNERS entry for .github/agents folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 * @ContentSquare/mobile
+
+# Protect .github/agents folder for GitHub Copilot agents
+/.github/agents/ @ContentSquare/mobile


### PR DESCRIPTION
## Description
Add a CODEOWNERS entry to protect the `.github/agents/` folder, ensuring @ContentSquare/mobile owns any files added there in the future.

## Motivation and Context
Proactively protect the GitHub agents folder so that when GitHub Copilot agent configurations are added, they will require review from the repository owners.

## Breaking Changes
No

## How Has This Been Tested?
N/A - CODEOWNERS configuration change only